### PR TITLE
为 `<ArticlesMenu>` 增加按拼音排序的功能

### DIFF
--- a/example/docs/campus/index.md
+++ b/example/docs/campus/index.md
@@ -14,4 +14,4 @@ category:
 
 ## 大学目录
 
-<ArticlesMenu />
+<ArticlesMenu sortByPinyin />

--- a/src/components/ArticlesMenu.vue
+++ b/src/components/ArticlesMenu.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { useRoute } from 'vitepress'
 import { computed } from 'vue'
+import { titleSorter } from '../utils/titleSorter'
 import { data } from './articlesmenu.data'
 
+const { sortByPinyin = false } = defineProps<{ sortByPinyin?: boolean }>()
 const route = useRoute()
-const articles = computed(() =>
-  data
+const articles = computed(() => {
+  const result = data
     .filter((article) => {
       if (!article.url.startsWith(route.path))
         return false
@@ -19,7 +21,12 @@ const articles = computed(() =>
         return false
       return true
     })
-    .map(article => ({ link: article.url, text: article.title })),
+    .map(article => ({ link: article.url, text: article.title }))
+  if (sortByPinyin) {
+    result.sort(titleSorter)
+  }
+  return result
+},
 )
 </script>
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,10 +1,10 @@
 import type {
-  SidebarItem,
   SidebarMultiItem,
   VitePressSidebarOptions,
 } from 'vitepress-sidebar/types'
 import { generateSidebar as genSidebar } from 'vitepress-sidebar'
 import { useThemeContext } from './utils/themeContext'
+import { titleSorter } from './utils/titleSorter'
 
 export function generateSidebar() {
   const { sidebarOptions } = useThemeContext()
@@ -13,21 +13,8 @@ export function generateSidebar() {
   for (const key in sidebar) {
     const sidebarMultiItem: SidebarMultiItem = (sidebar as any)[key]
     if (optionMap.get(sidebarMultiItem.base)?.sortMenusByFrontmatterOrder !== true) {
-      sidebarMultiItem.items.sort(sidebarTitleSorter)
+      sidebarMultiItem.items.sort(titleSorter)
     }
   }
   return sidebar
-}
-
-function sidebarTitleSorter(infoA: SidebarItem, infoB: SidebarItem): number {
-  const textA = infoA.text
-  const textB = infoB.text
-  if (textA === undefined || textB === undefined)
-    return 0
-
-  const infoANfc = textA.normalize('NFC')
-  const infoBNfc = textB.normalize('NFC')
-  return infoANfc.localeCompare(infoBNfc, 'zh', {
-    numeric: true,
-  })
 }

--- a/src/utils/titleSorter.ts
+++ b/src/utils/titleSorter.ts
@@ -1,0 +1,14 @@
+import type { SidebarItem } from 'vitepress-sidebar/types'
+
+export function titleSorter(infoA: SidebarItem, infoB: SidebarItem): number {
+  const textA = infoA.text
+  const textB = infoB.text
+  if (textA === undefined || textB === undefined)
+    return 0
+
+  const infoANfc = textA.normalize('NFC')
+  const infoBNfc = textB.normalize('NFC')
+  return infoANfc.localeCompare(infoBNfc, 'zh', {
+    numeric: true,
+  })
+}


### PR DESCRIPTION
本 PR 用于解决 #19 ( closes #19 )

## 内容

为 `<ArticlesMenu>` 添加了一个 `sortByPinyin` 属性，有它的时候里面内容就会按拼音排序。这需要在本 PR 合并后再在 rle.wiki 文件里修改

## 预览

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/160bfa21-d0e8-44e9-9617-70bf5431993f" />

## 关于代码结构变动的说明

将 `sidebarTitleSorter` 函数更名为 `titleSorter`，因为它现在不只用于侧边栏了。将它单独拆分到了一个文件里面，否则会导致循环依赖问题